### PR TITLE
Cygwin fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@
 KEXT_NAME = NormalizInterface
 KEXT_SOURCES = src/normaliz.cc
 
-KEXT_CXXFLAGS = @NORMALIZ_CPPFLAGS@ -std=c++11
+KEXT_CXXFLAGS = @NORMALIZ_CPPFLAGS@ -std=gnu++11
 KEXT_LDFLAGS = -lstdc++ -R@NORMALIZ_LDPATH@ @NORMALIZ_LDFLAGS@ -lnormaliz
 
 KEXT_RECONF ?= ./config.status Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,9 @@
 KEXT_NAME = NormalizInterface
 KEXT_SOURCES = src/normaliz.cc
 
-KEXT_CXXFLAGS = @NORMALIZ_CPPFLAGS@ -std=gnu++11
+# workaround for GAP 4.11: we need _POSIX_C_SOURCE=1 to avoid an error during compilation;
+# see https://github.com/gap-packages/NormalizInterface/pull/91 for details
+KEXT_CXXFLAGS = @NORMALIZ_CPPFLAGS@ -std=c++11 -D_POSIX_C_SOURCE=1
 KEXT_LDFLAGS = -lstdc++ -R@NORMALIZ_LDPATH@ @NORMALIZ_LDFLAGS@ -lnormaliz
 
 KEXT_RECONF ?= ./config.status Makefile

--- a/build-normaliz.sh
+++ b/build-normaliz.sh
@@ -116,3 +116,12 @@ else
 fi
 make -j4
 make install
+
+if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+    echo "##"
+    echo "## Extra Cygwin installation step"
+    echo "##"
+    # We have to move the Normalize dll to $GAPDIR/.libs, as this is the only
+    # place which Cygwin will check for it inside $GAPDIR.
+    cp ${NormalizInstallDir}/bin/cygnormaliz-*.dll "${GAPDIR}/.libs"
+fi

--- a/build-normaliz.sh
+++ b/build-normaliz.sh
@@ -117,7 +117,8 @@ fi
 make -j4
 make install
 
-if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+osname=$(uname -s)
+if [ "${osname#*$CYGWIN}" != "$osname" ]; then
     echo "##"
     echo "## Extra Cygwin installation step"
     echo "##"


### PR DESCRIPTION
This PR fixes two problems which stop NormalizInterface working in Cygwin/Windows.

1) Switch to using gnu++11 instead of c++11. This is because GAP's configure script it built using the default compiler settings, which enable gnu extensions. I don't know if this could break another OS, but the same switch was made in Semigroups and doesn't seem to have caused problems.

2) Move the normaliz DLL to gaproot/.libs. This does look horrible, but in windows I can use ProcessMonitor and this is the only place inside GAPROOT which is checked for this file. We could alternatively install it globall, in /usr/lib say (still inside the Cygwin root obviously).

With these two changes, the package works fine in Cygwin, and passes testall.g