### PR TITLE
Do not use `shasum` before checking that its available

### DIFF
--- a/etc/download.sh
+++ b/etc/download.sh
@@ -54,7 +54,6 @@ while : ; do
     #
     # Compute checksum
     #
-    ActualChecksum=$(shasum -a 256 ${Filename})
     echo "Verifying SHA256 checksum of ${Filename}..."
     if command -v sha256sum >/dev/null 2>&1 ; then
         ActualChecksum=$(sha256sum ${Filename})


### PR DESCRIPTION
I guess that this line should have been replaced by the lines following it, but was kept by accident.