### PR TITLE
Cygwin fixes

### DIFF
--- a/build-normaliz.sh
+++ b/build-normaliz.sh
@@ -118,7 +118,7 @@ make -j4
 make install
 
 osname=$(uname -s)
-if [ "${osname#*$CYGWIN}" != "$osname" ]; then
+if [ "${osname#*CYGWIN}" != "$osname" ]; then
     echo "##"
     echo "## Extra Cygwin installation step"
     echo "##"

--- a/src/normaliz.cc
+++ b/src/normaliz.cc
@@ -420,7 +420,7 @@ bool GAPToNmz(long & out, Obj x)
 bool GAPToNmz(mpz_class & out, Obj x)
 {
     if (IS_INTOBJ(x)) {
-        out = (mp_limb_signed_t)INT_INTOBJ(x);
+        out = INT_INTOBJ(x);
         return true;
     }
     else if (TNUM_OBJ(x) == T_INTPOS || TNUM_OBJ(x) == T_INTNEG) {
@@ -437,7 +437,7 @@ bool GAPToNmz(mpz_class & out, Obj x)
 bool GAPToNmz(mpq_class & out, Obj x)
 {
     if (IS_INTOBJ(x)) {
-        out = (mp_limb_signed_t)INT_INTOBJ(x);
+        out = INT_INTOBJ(x);
         return true;
     }
     else if (TNUM_OBJ(x) == T_INTPOS || TNUM_OBJ(x) == T_INTNEG) {


### PR DESCRIPTION
Two cygwin fixes, one old, one new.

The older one (from the last time we handled cygwin), was a typo in how we detect cygwin:

```
caj@DESKTOP-J1BT2AU ~/sage-windows/Output
$ osname=$(uname -s)

caj@DESKTOP-J1BT2AU ~/sage-windows/Output
$ echo $osname ${osname#*$CYGWIN} ${osname#*CYGWIN}
CYGWIN_NT-10.0 CYGWIN_NT-10.0 _NT-10.0
```

The other one is undoing an earlier commit -- on Cygwin, `mp_limb_signed_t` is `long long`, which isn't valid to assign to an `mpz_class` (I post the error message below). The docs for `mpz_class` say "All the standard C++ types may be used, except long long and long double,", so I'm not positive what ` 791925f2` (where these casts were introduced) were fixing.

The reason this bug didn't occur previously in cygwin is we used to only build in 32-bit mode, it seems to be in 64-bit mode where `mp_limb_signed_t` is `long long`.

```

src/normaliz.cc: In function ‘bool GAPToNmz(mpz_class&, Obj)’:
src/normaliz.cc:423:45: error: ambiguous overload for ‘operator=’ (operand types are ‘mpz_class’ and ‘mp_limb_signed_t’ {aka ‘long long int’})
  423 |         out = (mp_limb_signed_t)INT_INTOBJ(x);
      |                                             ^
In file included from /opt/gap-master/pkg/NormalizInterface-1.3.0/NormalizInstallDir/include/libnormaliz/general.h:65,
                 from /opt/gap-master/pkg/NormalizInterface-1.3.0/NormalizInstallDir/include/libnormaliz/libnormaliz.h:27,
                 from src/normaliz.cc:31:
/usr/include/gmpxx.h:1672:16: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(const __gmp_expr<__mpz_struct [1], __mpz_struct [1]>&)’
 1672 |   __gmp_expr & operator=(const __gmp_expr &z)
      |                ^~~~~~~~
/usr/include/gmpxx.h:1675:16: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(__gmp_expr<__mpz_struct [1], __mpz_struct [1]>&&)’
 1675 |   __gmp_expr & operator=(__gmp_expr &&z) noexcept
      |                ^~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(signed char)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(unsigned char)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(unsigned int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(short int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(short unsigned int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(long int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(long unsigned int)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(float)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gmpxx.h:1682:3: note: candidate: ‘__gmp_expr<__mpz_struct [1], __mpz_struct [1]>& __gmp_expr<__mpz_struct [1], __mpz_struct [1]>::operator=(double)’
 1682 |   __GMPXX_DEFINE_ARITHMETIC_ASSIGNMENTS
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
