### PR TITLE
Add a CI job running on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,9 +29,14 @@ jobs:
           - stable-4.10
           - stable-4.9
         ABI: ['']
+        os: [ubuntu-latest]
         include:
           - gap-branch: master
             ABI: 32
+            os: ubuntu-latest
+          - gap-branch: master
+            ABI: ''
+            os: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ KEXT_SOURCES = src/normaliz.cc
 # instead of -std=c++11 to avoid an error during compilation; see
 # https://github.com/gap-packages/NormalizInterface/pull/91 for details
 KEXT_CXXFLAGS = @CPPFLAGS@ @NORMALIZ_CPPFLAGS@ -std=gnu++11
-KEXT_LDFLAGS = @LDFLAGS@ -lgmp @NORMALIZ_LDFLAGS@ -lnormaliz
+KEXT_LDFLAGS = @LDFLAGS@ -lgmp @NORMALIZ_LDFLAGS@ -lnormaliz -lstdc++
 
 KEXT_USE_AUTOCONF = 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,11 @@ AC_ARG_WITH([normaliz],
     [AS_HELP_STRING([--with-normaliz=<path>], [specify root of Normaliz installation])],
     [NORMALIZ="$with_normaliz"],
     [NORMALIZ="$PWD/NormalizInstallDir"
-     NORMALIZ_RPATH_EXTRA="-Wl,-rpath=$NORMALIZ/lib"
+     # The following is a hack to ensure compatibility with versions of gac that
+     # don't use GNU libtool anymore, and thus don't set a run path pointing to
+     # the specific version of libnormaliz we requested. Without this, when GAP
+     # loads NormalizInterface.so it may not find the libnormaliz shared library.
+     NORMALIZ_RPATH_EXTRA="-Wl,-rpath -Wl,$NORMALIZ/lib"
     ]
 )
 NORMALIZ_CPPFLAGS="-I$NORMALIZ/include"


### PR DESCRIPTION
I noticed that a recent change I made broke things on macOS (oops!). This PR adds a CI test on macOS to prevent similar regressions in the future. It also fixes on part of the issue.

The other part is that GAC is invoking gcc for linking, and that doesn't work here because of the C++ code. I am not yet sure what the best way to fix this. I could e.g. change gac to always use the C++ compiler for linking, but I am not sure if this will break even more stuff, so...