### PR TITLE
Rename `build-normaliz.sh` to `prerequisites.sh`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,9 +48,6 @@ jobs:
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
           ABI: ${{ matrix.ABI }}
-      - name: 'Install additional dependencies'
-        run: |
-          ./build-normaliz.sh $HOME/gap
       - uses: gap-actions/build-pkg@v1
         with:
           ABI: ${{ matrix.ABI }}

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 This file describes changes in the NormalizInterface package.
 
+1.3.5 (2022-MM-DD)
+  - Rename `build-normaliz.sh` to `prerequisites.sh` to match an
+    undocumented convention used across several packages.
+
 1.3.4 (2022-08-07)
   - Fix regression that broke building NormalizInterface on macOS
 

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ in addition to a C++11 compiler:
  * curl OR wget for downloading the source code
 
 Once you have installed these, you can build Normaliz by using the
-`build-normaliz.sh` script provided by us. If NormalizInterface is
+`prerequisites.sh` script provided by us. If NormalizInterface is
 installed inside the `pkg` directory of your GAP installation, you
 can simply invoke it from inside the NormalizInterface directory as
 follows:
 
-    ./build-normaliz.sh
+    ./prerequisites.sh
 
 Otherwise, you have to tell the script where your GAP directory is,
 by passing it as an argumnt:
 
-    ./build-normaliz.sh GAPDIR
+    ./prerequisites.sh GAPDIR
 
 Not specifying GAPDIR is equivalent to passing `../..` as GAPDIR. If
 more than one argument is specified, then any arguments beyond the

--- a/doc/intro.autodoc
+++ b/doc/intro.autodoc
@@ -97,9 +97,9 @@ enter the following commands:
 <P/>
 
 <Listing><![CDATA[
-    make clean
-    ./configure --with-gmp=PATH/TO/YOUR/GMP
-    make
+make clean
+./configure --with-gmp=PATH/TO/YOUR/GMP
+make
 ]]></Listing>
 
 Next you need to compile a recent version of Normaliz. This requires the
@@ -110,12 +110,12 @@ via your system's package manager. At least the following are required:
  * curl OR wget for downloading the source code
 
 Once you have installed these, you can build Normaliz by using
-the build-normaliz.sh script we provide. It takes a single,
+the `prerequisites.sh` script we provide. It takes a single,
 optional parameter: the location of the GAP root directory.
 <P/>
 
 <Listing><![CDATA[
-    ./build-normaliz.sh GAPDIR
+./prerequisites.sh GAPDIR
 ]]></Listing>
 
 Once it completed successfully, you can then build NormalizInterface
@@ -123,6 +123,6 @@ like this:
 <P/>
 
 <Listing><![CDATA[
-    ./configure --with-gaproot=GAPDIR
-    make
+./configure --with-gaproot=GAPDIR
+make
 ]]></Listing>

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -4,7 +4,7 @@
 # To use it, pass the location of your GAP installation
 # to it:
 #
-#  ./build-normaliz.sh GAPDIR
+#  ./prerequisites.sh GAPDIR
 #
 #  Then you can compile NormalizInterface as follows:
 #


### PR DESCRIPTION
This matche an undocumented convention used across several packages,
which is supported by e.g. the `BuildPackage.sh` script and by the
GitHub Action `gap-actions/build-pkg`.
