### PR TITLE
Fix cygwin when GAP is built without libtool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,26 @@ jobs:
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v3
 
+  test-cygwin:
+    name: "cygwin64 - GAP master"
+    runs-on: windows-latest
+    env:
+      CHERE_INVOKING: 1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gap-actions/setup-cygwin@v1
+      - uses: gap-actions/setup-gap@cygwin-v2
+        with:
+          GAP_PKGS_TO_BUILD: "normalizinterface profiling io"
+      - uses: gap-actions/build-pkg@cygwin-v1
+      - uses: gap-actions/run-pkg-tests@cygwin-v2
+      - uses: gap-actions/process-coverage@cygwin-v2
+      - uses: codecov/codecov-action@v3
+      - name: "Setup tmate session"
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
+        timeout-minutes: 15
+
   # The documentation job
   manual:
     name: Build manuals

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -124,5 +124,10 @@ if [ "${osname#*CYGWIN}" != "$osname" ]; then
     echo "##"
     # We have to move the Normalize dll to $GAPDIR/.libs, as this is the only
     # place which Cygwin will check for it inside $GAPDIR.
-    cp ${NormalizInstallDir}/bin/cygnormaliz-*.dll "${GAPDIR}/.libs"
+
+    # If using an older GAP built with libtool, put in .libs
+    if test -d ${GAPDIR}/.libs; then cp ${NormalizInstallDir}/bin/cygnormaliz-*.dll ${GAPDIR}/.libs/ ; fi
+    # For newer GAP, put in root directory (this is fine for older GAPs)
+    cp ${NormalizInstallDir}/bin/cygnormaliz-*.dll "${GAPDIR}/"
+
 fi


### PR DESCRIPTION
Because windows is stupid, we have to move the normalizinterface DLL to a place where windows will look for it. This used to be the `.libs` directory made by `libtool`, but now we don't use libtool, it's just GAPDIR. Just in case someone wants to use the latest normalizinterface on an older GAP, I still copy it into `.libs`, if the directory exists.

I added a cygwin test to CI, to test this works.