### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/normaliz.cc
+++ b/src/normaliz.cc
@@ -23,7 +23,7 @@
 #! @Section YOU FORGOT TO SET A SECTION
 */
 
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 
 #if GAP_KERNEL_MAJOR_VERSION < 8
 #define BOOL Int


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
