### PR TITLE
Update normaliz version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and especially have a look at the manual.
 
 NormalizInterface supports GAP 4.9 or later, and Normaliz 3.5.4 or later.
 However, we recommend using the most recent versions -- at the time this
-is written, that means GAP 4.14.0 and Normaliz 3.11.1.
+is written, that means GAP 4.15.1 and Normaliz 3.11.1.
 
 Assuming you have a suitable version installed, you still need to
 compile Normaliz. There is a complicating factor, however: Normaliz

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and especially have a look at the manual.
 
 NormalizInterface supports GAP 4.9 or later, and Normaliz 3.5.4 or later.
 However, we recommend using the most recent versions -- at the time this
-is written, that means GAP 4.14.0 and Normaliz 3.10.x.
+is written, that means GAP 4.14.0 and Normaliz 3.11.1.
 
 Assuming you have a suitable version installed, you still need to
 compile Normaliz. There is a complicating factor, however: Normaliz


### PR DESCRIPTION
To match https://github.com/gap-packages/NormalizInterface/pull/123.

I noticed this due to failures in https://github.com/oscar-system/GAP.jl/actions/runs/25368271643/job/74384840810?pr=1379.

cc @fingolfin 